### PR TITLE
Add `Inspirehep` to scientific papers sources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Selected Space & Physics projects:
 
 * [arXiv](https://arxiv.org/) - A free distribution service and an open-access archive.
 * [ADS](https://ui.adsabs.harvard.edu/) - Astrophysics Data System.
+* [Inspirehep](https://inspirehep.net/) - Astrophysics papers database with focus on astro particle-physics
 * [ResearchGate](https://www.researchgate.net/) - A European commercial social networking site for scientists and researchers.
 
 ## Databases


### PR DESCRIPTION
Hi 

I think [Inspirehep](https://inspirehep.net/) will be a good fit for research papers source (And information about researchers themselved). While it focus mainly on High energy physics but it includes both Astro particle physics and Astrophysics. There are subjects and one of them are `Astrophysics` which you will find general astrophysics that even doesn't have particle physics intersection. 